### PR TITLE
Update base image to fix build problems and psutil dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Created by https://www.gitignore.io/api/visualstudiocode
+# Edit at https://www.gitignore.io/?templates=visualstudiocode
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+
+# End of https://www.gitignore.io/api/visualstudiocode

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -74,7 +74,7 @@ ENV RENKU_DISABLE_VERSION_CHECK 1
 
 RUN pip install pipx && \
     pipx install --spec /wheels/renku*.whl renku && \
-    echo "export PATH=~/.local/bin:$PATH" >> /home/$NB_USER/.bashrc
+    pipx ensurepath
 
 COPY git-config.bashrc /home/$NB_USER/
 RUN cat /home/$NB_USER/git-config.bashrc >> /home/$NB_USER/.bashrc && rm /home/$NB_USER/git-config.bashrc

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,5 +1,5 @@
 # Build as renku/singleuser
-# Run with the DockerSpawner in JupyterHub
+# Run with the RenkuKubeSpawner via JupyterHub
 
 ARG JUPYTERHUB_VERSION=0.9.2
 ARG BASE_IMAGE=jupyterhub/singleuser:$JUPYTERHUB_VERSION
@@ -19,7 +19,8 @@ RUN apk add --no-cache git && \
 
 # build singleuser image
 FROM base
-MAINTAINER Swiss Data Science Center <info@datascience.ch>
+
+LABEL maintainer="Swiss Data Science Center <info@datascience.ch>"
 
 USER root
 # Copied from jupyter-minimal-notebook
@@ -38,10 +39,17 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     python-dev \
     unzip \
     vim \
+    musl-dev \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# link the musl library needed by psutil
+RUN ln -s /usr/lib/x86_64-linux-musl/libc.so /lib/libc.musl-x86_64.so.1
+
+# install git-lfs
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash && sudo apt-get install git-lfs=2.4.2
+
+# switch to the notebook user
 USER $NB_USER
 
 # install jupyterlab, papermill, git extension and renku-jupyterlab-ts
@@ -49,23 +57,24 @@ COPY requirements.txt /tmp/requirements.txt
 RUN python3 -m pip install -U pip && \
     pip install -r /tmp/requirements.txt && \
     jupyter labextension update @jupyterlab/hub-extension --no-build && \
-    jupyter labextension install @jupyterlab/git --no-build && \
+    jupyter labextension install @jupyterlab/git && \
     jupyter labextension install renku-jupyterlab-ts --no-build && \
     jupyter lab build && \
     jupyter labextension list && \
-    python3 -m pip install -e git+https://github.com/jupyterlab/jupyterlab-git.git#egg=jupyterlab_git && \
+    pip install jupyterlab-git==0.5.0 && \
     jupyter serverextension enable --py jupyterlab_git
+
+# fix https://github.com/SwissDataScienceCenter/renku-jupyter/issues/14
+RUN conda install gxx_linux-64
 
 # install renku-python
 COPY --from=renku /wheels /wheels
 
 ENV RENKU_DISABLE_VERSION_CHECK 1
-RUN conda create -y -n renku python=3.6 && \
-    $CONDA_DIR/envs/renku/bin/pip install --no-cache-dir /wheels/renku*.whl && \
-    conda clean --yes --all && \
-    mkdir -p /home/$NB_USER/.renku/bin && \
-    ln -s $CONDA_DIR/envs/renku/bin/renku /home/$NB_USER/.renku/bin/renku && \
-    echo "export PATH=~/.renku/bin:$PATH" >> /home/$NB_USER/.bashrc
+
+RUN pip install pipx && \
+    pipx install --spec /wheels/renku*.whl renku && \
+    echo "export PATH=~/.local/bin:$PATH" >> /home/$NB_USER/.bashrc
 
 COPY git-config.bashrc /home/$NB_USER/
 RUN cat /home/$NB_USER/git-config.bashrc >> /home/$NB_USER/.bashrc && rm /home/$NB_USER/git-config.bashrc

--- a/docker/cuda-9.2/Dockerfile
+++ b/docker/cuda-9.2/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE=renku/singleuser:latest
 FROM $BASE_IMAGE
 
-MAINTAINER Swiss Data Science Center <info@datascience.ch>
+LABEL maintainer="Swiss Data Science Center <info@datascience.ch>"
 
 # Install cuda
 # From: https://gitlab.com/nvidia/cuda/blob/ubuntu18.04/9.2/base/Dockerfile
@@ -36,4 +36,4 @@ ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 ENV NVIDIA_REQUIRE_CUDA "cuda>=9.2"
-USER jovyan
+USER $NB_USER

--- a/docker/r/Dockerfile
+++ b/docker/r/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=renku/singleuser:latest
 
 FROM $BASE_IMAGE
 
-MAINTAINER Swiss Data Science Center <info@datascience.ch>
+LABEL maintainer="Swiss Data Science Center <info@datascience.ch>"
 
 USER root
 


### PR DESCRIPTION
* adds `gxx_linux-64` via `apt-get` to resolve the failing build (see #14)
* installs `musl-dev` to resolve the psutil failure on `renku update` (see #14)
* install renku via `pipx` instead of conda
* also, replace deprecated `MAINTAINER` with `LABEL maintainer=< >` in Dockerfiles

You can pull `rrrrrok/base:latest` to check the image. 
