### PR TITLE
pre-stop and post-start pod lifecycle scripts

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -64,6 +64,8 @@ RUN pipx install ${RENKU_PIP_SPEC} --pip-args="--pre" renku && \
 COPY git-config.bashrc /home/$NB_USER/
 RUN cat /home/$NB_USER/git-config.bashrc >> /home/$NB_USER/.bashrc && rm /home/$NB_USER/git-config.bashrc
 
+COPY lifecycle/ /usr/local/bin/
+
 # Add user `jovyan` to sudoers (passwordless)
 USER root
 RUN echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \

--- a/docker/base/lifecycle/pre-stop.sh
+++ b/docker/base/lifecycle/pre-stop.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+GIT_STATUS=`git status -s`
+if [ -z "$GIT_STATUS" ] ; then
+  exit 0
+fi
+
+CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+CURRENT_SHA=`git rev-parse --short HEAD`
+AUTOSAVE_BRANCH="renku/autosave/$JUPYTERHUB_USER/${CURRENT_BRANCH}/${CURRENT_SHA}"
+git checkout -b "$AUTOSAVE_BRANCH"
+git add .
+git commit -am "Auto-saving for $JUPYTERHUB_USER on branch $CURRENT_BRANCH and commit $CURRENT_SHA"
+git push origin "$AUTOSAVE_BRANCH"
+git checkout master
+git branch -D "$AUTOSAVE_BRANCH"


### PR DESCRIPTION
This is a jupyter part of the issue raised for `renku-notebooks` (https://github.com/SwissDataScienceCenter/renku-notebooks/issues/126)
It introduces `pre-stop` and `post-start` scripts to be executed by Kubernetes when jupyter container got created and before killing.