### PR TITLE
feat: add graphviz to base image

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -15,17 +15,18 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     curl \
     git \
     gnupg \
+    graphviz \
+    less \
     libsm6 \
     libxext-dev \
     libxrender1 \
     lmodern \
+    musl-dev \
     nano \
     netcat \
     python-dev \
     unzip \
     vim \
-    musl-dev \
-    less \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
`renku log --format dot` needs graphviz for generating the png file. This PR installs graphviz by default into the base image. 