### PR TITLE
fix: remove jupyterlab extension

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -45,10 +45,9 @@ RUN python3 -m pip install -U pip && \
     pip install -r /tmp/requirements.txt && \
     jupyter labextension update @jupyterlab/hub-extension --no-build && \
     jupyter labextension install @jupyterlab/git && \
-    jupyter labextension install renku-jupyterlab-ts --no-build && \
     jupyter lab build && \
     jupyter labextension list && \
-    pip install jupyterlab-git==0.5.0 && \
+    pip install jupyterlab-git && \
     jupyter serverextension enable --py jupyterlab_git
 
 # fix https://github.com/SwissDataScienceCenter/renku-jupyter/issues/14

--- a/docker/base/requirements.txt
+++ b/docker/base/requirements.txt
@@ -1,3 +1,3 @@
-papermill
+papermill>=1.0.0
 requests>=2.20.0
-jupyterlab>=0.35.4
+jupyterlab>=1.0.0


### PR DESCRIPTION
The renku-jupyterlab-ts extension does not work yet with
JupyterLab>=1.0.0 -- it requires significant updates in
any case, so it should be removed until these issues
are resolved.

closes #39
closes #40