### PR TITLE
build(r): use rocker as a base image for R

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017, 2018 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2019 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #
@@ -64,6 +64,7 @@ pull:
 %:
 	cd docker/$@ && \
 	docker build \
+		--build-arg RENKU_PIP_SPEC=${RENKU_PIP_SPEC} \
 		--build-arg BASE_IMAGE=$(DOCKER_PREFIX):$(DOCKER_LABEL)$(RENKU_TAG) \
 		-t $(DOCKER_PREFIX)-$@:$(DOCKER_LABEL)$(RENKU_TAG) . && \
 	docker tag $(DOCKER_PREFIX)-$@:$(DOCKER_LABEL)$(RENKU_TAG) $(DOCKER_PREFIX)-$@:$(GIT_MASTER_HEAD_SHA)$(RENKU_TAG)

--- a/docker/r/Dockerfile
+++ b/docker/r/Dockerfile
@@ -1,40 +1,95 @@
-ARG BASE_IMAGE=renku/singleuser:latest
-
-FROM $BASE_IMAGE
-
+ARG RVERSION=3.6.1
+FROM rocker/rstudio:${RVERSION}
 LABEL maintainer="Swiss Data Science Center <info@datascience.ch>"
+
+# The initial setup is based on https://github.com/rocker-org/binder
 
 USER root
 
-# R pre-requisites
+ENV NB_USER rstudio
+ENV NB_UID 1000
+ENV VENV_DIR /srv/venv
+ENV HOME /home/${NB_USER}
+ENV SHELL bash
+
+# Set ENV for all programs...
+ENV PATH ${VENV_DIR}/bin:$PATH
+# And set ENV for R! It doesn't read from the environment...
+RUN echo "PATH=${PATH}" >> /usr/local/lib/R/etc/Renviron && \
+    echo "PATH=${PATH}" >> /etc/profile.d/set_path.sh
+
+# The `rsession` binary that is called by nbrsessionproxy to start R doesn't seem to start
+# without this being explicitly set
+ENV LD_LIBRARY_PATH /usr/local/lib/R/lib
+
+
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    fonts-dejavu \
-    tzdata \
-    gfortran \
-    libapparmor1 \
-    libedit2 \
-    lsb-release \
-    psmisc \
-    libssl1.0.0 \
-    gcc && \
+    apt-get -y install \
+                       build-essential \
+                       checkinstall \
+                       curl \
+                       gnupg \
+                       libbz2-dev \
+                       libc6-dev \
+                       libffi-dev \
+                       libgdbm-dev \
+                       libncursesw5-dev \
+                       libreadline-gplv2-dev \
+                       libsqlite3-dev \
+                       libssl-dev \
+                       tk-dev \
+                       zlib1g-dev && \
+    apt-get purge && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-USER $NB_USER
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash && \
+    apt-get install git-lfs
 
-# R packages
-RUN conda install --quiet --yes \
-    'r-base=3.6.0' \
-    'r-irkernel' \
-    'r-devtools' \
-    'rstudio' && \
-    conda clean -tipsy && \
-    fix-permissions $CONDA_DIR
+# install python 3.7
+WORKDIR /usr/src
+RUN wget https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz && \
+    tar xzf Python-3.7.4.tgz
+WORKDIR /usr/src/Python-3.7.4
+RUN ./configure --enable-optimizations && \
+    make install
 
-# install R Jupyter extension
-RUN pip install git+https://github.com/jupyterhub/jupyter-rsession-proxy
+# Add Tini
+ENV TINI_VERSION v0.18.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
 
-# The desktop package uses /usr/lib/rstudio/bin
-ENV PATH="${PATH}:/usr/lib/rstudio-server/bin"
-ENV LD_LIBRARY_PATH="/usr/lib/R/lib:/lib:/usr/lib/x86_64-linux-gnu:/usr/lib/jvm/java-7-openjdk-amd64/jre/lib/amd64/server:/opt/conda/lib/R/lib"
+# Create a venv dir owned by unprivileged user & set up notebook in it
+# This allows non-root to install python libraries if required
+RUN mkdir -p ${VENV_DIR} && chown -R ${NB_USER} ${VENV_DIR}
+
+USER ${NB_USER}
+
+# install jupyter dependencies
+ARG JUPYTERHUB_VERSION=0.9.6
+RUN python3 -m venv ${VENV_DIR} && \
+    pip3 install -U --no-cache-dir pip wheel && \
+    pip3 install --no-cache-dir \
+         jupyter-rsession-proxy \
+         jupyterlab==1.0.0 \
+         jupyterhub==${JUPYTERHUB_VERSION}
+
+# install IRKernel and renv
+RUN R --quiet -e "install.packages('IRkernel')" && \
+    R --quiet -e "IRkernel::installspec(prefix='${VENV_DIR}')" && \
+    R --quiet -e "install.packages('remotes')" && \
+    R --quiet -e "remotes::install_github('rstudio/renv')"
+
+# install renku
+# the RENKU_PIP_SPEC should be e.g. "--spec renku==0.5.2"
+ARG RENKU_PIP_SPEC=""
+RUN pip3 install --no-cache-dir pipx && \
+    pipx install ${RENKU_PIP_SPEC} --pip-args="--pre" renku && \
+    pipx inject renku sentry-sdk && \
+    pipx ensurepath
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT [ "/tini", "--", "/entrypoint.sh" ]
+CMD [ "jupyterhub-singleuser" ]
+
+WORKDIR ${HOME}

--- a/docker/r/entrypoint.sh
+++ b/docker/r/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Copy the relevant system environment variables to the R-specific locations
+VariableArray=("GIT_COMMITTER_NAME"  "GIT_AUTHOR_NAME"  "EMAIL")
+for var in ${VariableArray[*]}; do
+    if [ -n "${!var}" ]; then
+        echo $var=${!var} >> ${HOME}/.Renviron
+    fi
+done
+
+# run the command
+$@


### PR DESCRIPTION
Use the [rocker-versioned](https://github.com/rocker-org/rocker-versioned) rstudio image as the base of our image. 