### PR TITLE
image: Cuda 10.0 Tensorflow 1.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@
 
 extensions = \
 	r \
-	cuda-9.2
+	cuda-9.2 \
+	cuda-10.0-tensorflow-1.14
 
 DOCKER_PREFIX?=renku/singleuser
 DOCKER_LABEL?=latest

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,7 @@
 
 extensions = \
 	r \
-	cuda-9.2 
-	#cuda-10.0-tensorflow-1.14
+	cuda-9.2 cuda-10.0-tensorflow-1.14
 
 DOCKER_PREFIX?=renku/singleuser
 DOCKER_LABEL?=latest

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@
 
 extensions = \
 	r \
-	cuda-9.2 \
-	cuda-10.0-tensorflow-1.14
+	cuda-9.2 
+	#cuda-10.0-tensorflow-1.14
 
 DOCKER_PREFIX?=renku/singleuser
 DOCKER_LABEL?=latest

--- a/docker/cuda-10.0-tensorflow-1.14/Dockerfile
+++ b/docker/cuda-10.0-tensorflow-1.14/Dockerfile
@@ -1,0 +1,84 @@
+ARG BASE_IMAGE=renku/singleuser:latest
+FROM $BASE_IMAGE
+
+LABEL maintainer="Swiss Data Science Center <info@datascience.ch>"
+
+## cuda base
+## from https://gitlab.com/nvidia/cuda/blob/ubuntu18.04/10.0/base/Dockerfile
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends gnupg2 curl ca-certificates && \
+    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub | apt-key add - && \
+    echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 /" > /etc/apt/sources.list.d/cuda.list && \
+    echo "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64 /" > /etc/apt/sources.list.d/nvidia-ml.list && \
+    apt-get purge --autoremove -y curl && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV CUDA_VERSION 10.0.130
+ENV CUDA_PKG_VERSION 10-0=$CUDA_VERSION-1
+
+# For libraries in the cuda-compat-* package: https://docs.nvidia.com/cuda/eula/index.html#attachment-a
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        cuda-cudart-$CUDA_PKG_VERSION \
+        cuda-compat-10-0 && \
+    ln -s cuda-10.0 /usr/local/cuda && \
+    rm -rf /var/lib/apt/lists/*
+
+# Required for nvidia-docker v1
+RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
+    echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+
+ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
+
+# nvidia-container-runtime
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+ENV NVIDIA_REQUIRE_CUDA "cuda>=10.0"
+
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
+
+## cuda runtime
+## https://gitlab.com/nvidia/container-images/cuda/blob/ubuntu18.04/10.0/runtime
+ENV NCCL_VERSION 2.4.2
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        cuda-libraries-$CUDA_PKG_VERSION \
+        cuda-nvtx-$CUDA_PKG_VERSION \
+        libnccl2=$NCCL_VERSION-1+cuda10.0 && \
+    apt-mark hold libnccl2 && \
+    rm -rf /var/lib/apt/lists/*
+
+## cuda devel
+## https://gitlab.com/nvidia/container-images/cuda/blob/ubuntu18.04/10.0/devel
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        cuda-libraries-dev-$CUDA_PKG_VERSION \
+        cuda-nvml-dev-$CUDA_PKG_VERSION \
+        cuda-minimal-build-$CUDA_PKG_VERSION \
+        cuda-command-line-tools-$CUDA_PKG_VERSION \
+        libnccl-dev=$NCCL_VERSION-1+cuda10.0 && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs
+
+
+## CUDNN 7 
+## https://gitlab.com/nvidia/container-images/cuda/blob/ubuntu18.04/10.0/devel/cudnn7
+ENV CUDNN_VERSION 7.6.0.64
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+            libcudnn7=$CUDNN_VERSION-1+cuda10.0 \
+            libcudnn7-dev=$CUDNN_VERSION-1+cuda10.0 && \
+    apt-mark hold libcudnn7 && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs
+
+USER $NB_USER
+
+## Tensorflow GPU
+RUN /opt/conda/bin/pip install tensorflow-gpu==1.14
+
+# Tensorboard jupyter extension 
+#RUN    pip install nbserverproxy \
+#    && jupyter serverextension enable --py nbserverproxy \
+#    && jupyter labextension install @renku/jupyterlab-vnc

--- a/docker/cuda-10.0-tensorflow-1.14/Dockerfile
+++ b/docker/cuda-10.0-tensorflow-1.14/Dockerfile
@@ -78,7 +78,6 @@ USER $NB_USER
 ## Tensorflow GPU
 RUN /opt/conda/bin/pip install tensorflow-gpu==1.14
 
-# Tensorboard jupyter extension 
-#RUN    pip install nbserverproxy \
-#    && jupyter serverextension enable --py nbserverproxy \
-#    && jupyter labextension install @renku/jupyterlab-vnc
+# Tensorboard jupyter(lab) extension 
+RUN jupyter labextension install jupyterlab_tensorboard && \
+    pip install jupyter-tensorboard

--- a/docker/cuda-10.0-tensorflow-1.14/Dockerfile
+++ b/docker/cuda-10.0-tensorflow-1.14/Dockerfile
@@ -80,4 +80,4 @@ RUN /opt/conda/bin/pip install tensorflow-gpu==1.14
 
 # Tensorboard jupyter(lab) extension 
 RUN jupyter labextension install jupyterlab_tensorboard && \
-    pip install jupyter-tensorboard
+    pip install jupyter-tensorboard==0.1.10


### PR DESCRIPTION
This PR provides a Renku image for Cuda 10.0 with Tensorflow 1.14
To test:
1. Go to https://limited.renku.ch/projects/51/launchNotebook 
2. Launch a notebook from the latest commit with GPUs and 8GBs of memory
3. From the notebook open a console and execute `python test-tensorflow-gpu.py`

Expected result: the program runs without errors and that at least one GPU device is listed in the logs (similar to https://limited.renku.ch/gitlab/pameladelgado/test2/blob/master/logs-gpu-test/test-log-2gpus.txt)

Fixes partially #19 . Tensorboard comes with the image, but to be able to access it we need to do some port forwarding before running the notebook (https://www.tensorflow.org/tensorboard/tensorboard_in_notebooks)

Update: closes #19 