### PR TITLE
build: bump Renku version matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
   - RENKU_VERSION="0.5.1"
   - RENKU_VERSION="0.5.2"
   - RENKU_VERSION="0.6.0"
-  - RENKU_VERSION="0.7.0"
+  - RENKU_VERSION="0.7.1"
 
 git:
   depth: false


### PR DESCRIPTION
To use `0.7.1`  instead of `0.7.0`