### PR TITLE
Updated renku version matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
   - RENKU_VERSION="0.5.1"
   - RENKU_VERSION="0.5.2"
   - RENKU_VERSION="0.6.0"
-  - RENKU_VERSION="0.7.0"
+  - RENKU_VERSION="0.7.1"
 
 git:
   depth: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ env:
   - RENKU_VERSION="0.5.0"
   - RENKU_VERSION="0.5.1"
   - RENKU_VERSION="0.5.2"
-  - RENKU_VERSION="0.6.0"
+  - RENKU_VERSION="0.6.1"
   - RENKU_VERSION="0.7.2"
 
 git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ env:
   - RENKU_VERSION="0.5.2"
   - RENKU_VERSION="0.6.1"
   - RENKU_VERSION="0.7.2"
-  - RENKU_VERSION="0.8.0"
+  - RENKU_VERSION="0.8.1"
 
 git:
   depth: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
   - RENKU_VERSION="0.5.1"
   - RENKU_VERSION="0.5.2"
   - RENKU_VERSION="0.6.0"
-  - RENKU_VERSION="0.7.1"
+  - RENKU_VERSION="0.7.2"
 
 git:
   depth: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,10 @@ python:
 
 env:
   - RENKU_VERSION=""
-  - RENKU_VERSION="0.5.0"
-  - RENKU_VERSION="0.5.1"
   - RENKU_VERSION="0.5.2"
   - RENKU_VERSION="0.6.1"
   - RENKU_VERSION="0.7.2"
+  - RENKU_VERSION="0.8.0"
 
 git:
   depth: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ sudo: required
 services:
   - docker
 
+branches:
+  only:
+    - master
+
 language: python
 
 python:

--- a/docker/r/Dockerfile
+++ b/docker/r/Dockerfile
@@ -76,7 +76,8 @@ RUN conda install --quiet --yes \
     'notebook=6.0.0' \
     "jupyterhub=${JUPYTERHUB_VERSION}" \
     'jupyterlab=1.0.9' \
-    'nodejs>=6.11.5' && \
+    'nodejs>=6.11.5' \
+    conda-build && \
     conda build purge-all  && \
     #conda clean --all -f -y && \
     npm cache clean --force 

--- a/docker/r/Dockerfile
+++ b/docker/r/Dockerfile
@@ -38,7 +38,8 @@ RUN apt-get update --fix-missing && \
         libsm6 \
         libxext6 \
         libxrender1 \
-        wget && \
+        wget \
+        vim && \
     apt-get purge && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/r/Dockerfile
+++ b/docker/r/Dockerfile
@@ -76,8 +76,8 @@ RUN conda install --quiet --yes \
     'notebook=6.0.0' \
     "jupyterhub=${JUPYTERHUB_VERSION}" \
     'jupyterlab=1.0.9' \
-    'nodejs>=6.11.5' \
-    conda-build \
+    'nodejs>=6.11.5'  && \
+    conda-build && \
     conda build purge-all  && \
     #conda clean --all -f -y && \
     npm cache clean --force 

--- a/docker/r/Dockerfile
+++ b/docker/r/Dockerfile
@@ -84,10 +84,10 @@ RUN conda install --quiet --yes \
 
 RUN jupyter notebook --generate-config && \
     rm -rf ${CONDA_PATH}/share/jupyter/lab/staging && \
-    rm -rf /home/$NB_USER/.cache/yarn 
+    rm -rf /home/$NB_USER/.cache/yarn && \
+    pip install -U --no-cache-dir pip wheel 
 
-RUN pip install -U --no-cache-dir pip wheel && \
-    pip install --no-cache-dir \
+RUN pip install --no-cache-dir \
         jupyter-rsession-proxy \
         jupyterlab==1.0.0 \
         jupyterlab-git && \
@@ -101,7 +101,7 @@ RUN R --quiet -e "install.packages('IRkernel')" && \
 # install renku
 # the RENKU_PIP_SPEC should be e.g. "--spec renku==0.5.2"
 ARG RENKU_PIP_SPEC=""
-RUN pip install --no-cache-dir pipx && \
+RUN pip install pipx && \
     pipx install ${RENKU_PIP_SPEC} --pip-args="--pre" renku && \
     pipx inject renku sentry-sdk && \
     pipx ensurepath

--- a/docker/r/Dockerfile
+++ b/docker/r/Dockerfile
@@ -76,7 +76,7 @@ RUN conda install --quiet --yes \
     'notebook=6.0.0' \
     "jupyterhub=${JUPYTERHUB_VERSION}" \
     'jupyterlab=1.0.9' \
-    'nodejs>=6.11.5'  && \
+    'nodejs>=6.11.5' \
     conda-build && \
     conda build purge-all  && \
     #conda clean --all -f -y && \

--- a/docker/r/Dockerfile
+++ b/docker/r/Dockerfile
@@ -77,13 +77,14 @@ RUN conda install --quiet --yes \
     "jupyterhub=${JUPYTERHUB_VERSION}" \
     'jupyterlab=1.0.9' \
     'nodejs>=6.11.5' && \
-    conda clean --all -f -y && \
-    npm cache clean --force && \
-    jupyter notebook --generate-config && \
+    conda build purge-all  && \
+    #conda clean --all -f -y && \
+    npm cache clean --force 
+
+RUN jupyter notebook --generate-config && \
     rm -rf ${CONDA_PATH}/share/jupyter/lab/staging && \
     rm -rf /home/$NB_USER/.cache/yarn 
-##&& \
-RUN df -h
+
 RUN pip install -U --no-cache-dir pip wheel && \
     pip install --no-cache-dir \
         jupyter-rsession-proxy \

--- a/docker/r/Dockerfile
+++ b/docker/r/Dockerfile
@@ -77,7 +77,7 @@ RUN conda install --quiet --yes \
     "jupyterhub=${JUPYTERHUB_VERSION}" \
     'jupyterlab=1.0.9' \
     'nodejs>=6.11.5' \
-    conda-build && \
+    conda-build \
     conda build purge-all  && \
     #conda clean --all -f -y && \
     npm cache clean --force 

--- a/docker/r/Dockerfile
+++ b/docker/r/Dockerfile
@@ -81,8 +81,10 @@ RUN conda install --quiet --yes \
     npm cache clean --force && \
     jupyter notebook --generate-config && \
     rm -rf ${CONDA_PATH}/share/jupyter/lab/staging && \
-    rm -rf /home/$NB_USER/.cache/yarn && \
-    pip install -U --no-cache-dir pip wheel && \
+    rm -rf /home/$NB_USER/.cache/yarn 
+##&& \
+RUN df -h
+RUN pip install -U --no-cache-dir pip wheel && \
     pip install --no-cache-dir \
         jupyter-rsession-proxy \
         jupyterlab==1.0.0 \

--- a/docker/r/entrypoint.sh
+++ b/docker/r/entrypoint.sh
@@ -8,8 +8,17 @@ for var in ${VariableArray[*]}; do
     fi
 done
 
+# Setup git user
+if [ -z "$(git config --global --get user.name)" ]; then
+    git config --global user.name "$GIT_AUTHOR_NAME"
+fi
+if [ -z "$(git config --global --get user.email)" ]; then
+    git config --global user.email "$EMAIL"
+fi
+
 # add a symlink to the project directory in /home/rstudio
 [ -n "$CI_PROJECT" ] && ln -s /work/${CI_PROJECT} /home/rstudio
+
 
 # run the command
 $@


### PR DESCRIPTION
Updated travis matrix to include bug fixes on renku-python `0.7.2`
Images not yet tested, will wait on travis to build them first.

Sorry for the merge author, I had some problems with configuring the merging tool which ended up in undoing my git user config. When I merge I will squash so that it disappears.

Addresses: [Prep new release](https://github.com/SwissDataScienceCenter/renku/issues/693)