### PR TITLE
Updated tags travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,14 +51,15 @@ script:
   - make all
 
 deploy:
-  - &script
-    provider: script
+  - provider: script
     skip_cleanup: true
     script: bash .travis-deploy.sh
-    on: &script_on
+    on:
       branch: master
       repo: SwissDataScienceCenter/renku-jupyter
-  - <<: *script
+  - provider: script
+    skip_cleanup: true
+    script: bash .travis-deploy.sh
     on:
-      <<: *script_on
       tags: true
+      repo: SwissDataScienceCenter/renku-jupyter

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ services:
 branches:
   only:
     - master
+    - "/(^\\d+\\.\\d+\\.\\d+$)/"
 
 language: python
 
@@ -51,15 +52,14 @@ script:
   - make all
 
 deploy:
-  - provider: script
+  - &script
+    provider: script
     skip_cleanup: true
     script: bash .travis-deploy.sh
-    on:
+    on: &script_on
       branch: master
       repo: SwissDataScienceCenter/renku-jupyter
-  - provider: script
-    skip_cleanup: true
-    script: bash .travis-deploy.sh
+  - <<: *script
     on:
+      <<: *script_on
       tags: true
-      repo: SwissDataScienceCenter/renku-jupyter


### PR DESCRIPTION
After adding 
```
branches:
  only:
    - master
```
travis is not accepting requests of tags for deployment.
The current configuration is equivalent to https://github.com/SwissDataScienceCenter/renku-graph/blob/master/.travis.yml which works.