### PR TITLE
feat: inject environment setup into session

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -36,6 +36,11 @@ RUN ln -s /usr/lib/x86_64-linux-musl/libc.so /lib/libc.musl-x86_64.so.1
 # install git-lfs
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash && sudo apt-get install git-lfs=2.8.0
 
+# Add Tini
+ENV TINI_VERSION v0.18.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
 # switch to the notebook user
 USER $NB_USER
 
@@ -70,5 +75,8 @@ USER root
 RUN echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
     rm -rf /wheels
 USER $NB_USER
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT [ "/tini", "--", "/entrypoint.sh" ]
 
 CMD '/usr/local/bin/start-singleuser.sh'

--- a/docker/base/entrypoint.sh
+++ b/docker/base/entrypoint.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
 
-# Copy the relevant system environment variables to the R-specific locations
-VariableArray=("GIT_COMMITTER_NAME"  "GIT_AUTHOR_NAME"  "EMAIL")
-for var in ${VariableArray[*]}; do
-    if [ -n "${!var}" ]; then
-        echo $var=${!var} >> ${HOME}/.Renviron
-    fi
-done
-
 # Setup git user
 if [ -z "$(git config --global --get user.name)" ]; then
     git config --global user.name "$GIT_AUTHOR_NAME"
@@ -15,9 +7,6 @@ fi
 if [ -z "$(git config --global --get user.email)" ]; then
     git config --global user.email "$EMAIL"
 fi
-
-# add a symlink to the project directory in /home/rstudio
-[ -n "$CI_PROJECT" ] && ln -s /work/${CI_PROJECT} /home/rstudio
 
 #
 # copy the environment from renku-env repo


### PR DESCRIPTION
This PR adds an entrypoint to the base image that copies the contents of the files found in the user's `renku-env` repository in the gitlab instance. It takes the oauth token from the environment and uses it to clone the private `renku-env` repo. If the repo isn't there it fails silently. The contents of all the files in the `renku-env` repository are _appended_ to the corresponding files in `$HOME`.

This requires the user to set up a private `renku-env` repository and it should be documented in the main docs. 

To test, you may either launch an environment from https://renkulab.io/projects/1464/ or use the image `rrrrrok/singleuser:entrypoint` in your own project. 

closes #64